### PR TITLE
Add --case option to create Angular-friendly entities and files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Options:
   -e, --engine    Database engine.
            [choices: "mssql", "postgres", "mysql", "mariadb"] [default: "mssql"]
   -o, --output    Where to place generated models.
+  -c, --case      Convert snake_case tables names to PascalCase entities and snake_case columns to camelCase properties
 ```
 ### Examples
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@types/mysql": "0.0.34",
     "@types/pg": "^6.1.41",
+    "change-case": "^3.0.1",
     "handlebars": "^4.0.10",
     "mssql": "^3.3.0",
     "mysql": "^2.14.1",

--- a/src/entity.mst
+++ b/src/entity.mst
@@ -1,28 +1,30 @@
 import {Index,Entity, PrimaryColumn, Column, OneToOne, OneToMany, ManyToOne, JoinColumn} from "typeorm";
-{{relationImports}}
+{{#each Imports}}
+import {{curly true}}{{toEntityName this}}{{curly false}} from "./{{toFileName this}}";
+{{/each}}
 
-@Entity()
+@Entity("{{toEntityName EntityName}}")
 {{#Indexes}}{{^isPrimaryKey}}@Index("{{name}}",[{{#columns}}"{{name}}",{{/columns}}]{{#isUnique}},{unique:true}{{/isUnique}})
-{{/isPrimaryKey}}{{/Indexes}}export class {{EntityName}} {
+{{/isPrimaryKey}}{{/Indexes}}export class {{toEntityName EntityName}} {
+{{#Columns}}
 
-    {{#Columns}}
+{{~^relations}}	@Column("{{sql_type}}", {{curly true}}{{#is_generated}}generated: true,{{/is_generated}}
+		name: "{{name}}",{{#is_nullable}}
+		nullable: true,{{/is_nullable}}{{^is_nullable}}
+		nullable: false,{{/is_nullable}}{{#char_max_lenght}}
+		length: {{.}},{{/char_max_lenght}}{{#default}}
+		default: "{{.}}",{{/default}}{{#numericPrecision}}
+		precision:{{.}},{{/numericPrecision}}{{#numericScale}}
+		scale: {{.}},{{/numericScale}}{{#isPrimary}}
+		primary: {{isPrimary}},{{/isPrimary}}
+	})
+	{{toPropertyName name}}: {{ts_type}};
+{{/relations~}}
 
-   {{^relations}} @Column("{{sql_type}}",{ {{#is_generated}}
-        generated:true,{{/is_generated}}{{#is_nullable}}
-        nullable:true,{{/is_nullable}}{{^is_nullable}}
-        nullable:false,{{/is_nullable}}{{#char_max_lenght}}
-        length:{{.}},{{/char_max_lenght}}{{#default}}
-        default:"{{.}}",{{/default}}{{#numericPrecision}}
-        precision:{{.}},{{/numericPrecision}}{{#numericScale}}
-        scale:{{.}},{{/numericScale}}{{#isPrimary}}
-        primary:{{isPrimary}},{{/isPrimary}} 
-        })
-    {{name}}:{{ts_type}};
-        {{/relations}}{{#relations}}
-    @{{relationType}}(type=>{{relatedTable}}, {{../name}}=>{{../name}}.{{#if isOwner}}{{ownerColumn}}{{else}}{{relatedColumn}}{{/if}}){{#isOwner}}
-    @JoinColumn(){{/isOwner}}
-    {{#if isOneToMany}}{{../name}}:{{relatedTable}}[];
-    {{else}}{{../name}}:{{relatedTable}};
-    {{/if}}{{/relations}}
-    {{/Columns}}
+{{~#relations}}	@{{relationType}}(type => {{toEntityName relatedTable}}, {{toPropertyName ../name}} => {{toPropertyName ../name}}.{{#if isOwner}}{{toPropertyName ownerColumn}}{{else}}{{toPropertyName relatedColumn}}{{/if}}){{#isOwner}}
+	@JoinColumn(){{/isOwner}}
+	{{#if isOneToMany}}{{toPropertyName ../name}}: {{toEntityName relatedTable}}[];{{else}}{{toPropertyName ../name}}: {{toEntityName relatedTable}};{{/if}}
+{{/relations~}}
+{{"\n"}}
+{{/Columns}}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,10 @@ var argv = Yargs
         describe: 'Where to place generated models.',
         default: path.resolve(process.cwd(), 'output')
     })
+    .option('c', {
+        alias: 'case',
+        describe: 'Convert snake_case tables names to PascalCase entities and snake_case columns to camelCase properties'
+    })
     .argv;
 
 
@@ -82,7 +86,8 @@ let engine = new Engine(
         user: argv.u,
         password: argv.x,
         databaseType: argv.e,
-        resultsPath: argv.o
+        resultsPath: argv.o,
+        convertCase: !!argv.c
     });
 
 console.log(`[${new Date().toLocaleTimeString()}] Starting creation of model classes.`);

--- a/src/models/EntityInfo.ts
+++ b/src/models/EntityInfo.ts
@@ -5,26 +5,6 @@ import { ColumnInfo } from './ColumnInfo'
 export class EntityInfo {
     EntityName: string;
     Columns: ColumnInfo[];
+    Imports: string[];
     Indexes: IndexInfo[];
-
-    relationImports(): any {
-            var returnString = "";
-            var imports: string[] = [];
-            this.Columns.forEach((column) => {
-                column.relations.forEach(
-                    (relation) => {
-                        if (this.EntityName!=relation.relatedTable)
-                        imports.push(relation.relatedTable);
-                    }
-                )
-            });
-            imports.filter(function (elem, index, self) {
-                return index == self.indexOf(elem);
-            }).forEach((imp)=>{
-                returnString+=`import {${imp}} from './${imp}'\n`
-            })
-
-            return returnString;
-    }
-  
 }

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -141,7 +141,8 @@ async function createMSSQLModels(filesOrgPath: string, resultsPath: string): Pro
             user: process.env.MSSQL_Username,
             password: process.env.MSSQL_Password,
             databaseType: 'mssql',
-            resultsPath: resultsPath
+            resultsPath: resultsPath,
+            convertCase: true
         });
 
 
@@ -184,7 +185,8 @@ async function createPostgresModels(filesOrgPath: string, resultsPath: string): 
             user: process.env.POSTGRES_Username,
             password: process.env.POSTGRES_Password,
             databaseType: 'postgres',
-            resultsPath: resultsPath
+            resultsPath: resultsPath,
+            convertCase: true
         });
 
 
@@ -228,7 +230,8 @@ async function createMysqlModels(filesOrgPath: string, resultsPath: string): Pro
             user: process.env.MYSQL_Username,
             password: process.env.MYSQL_Password,
             databaseType: 'mysql',
-            resultsPath: resultsPath
+            resultsPath: resultsPath,
+            convertCase: true
         });
 
 
@@ -271,7 +274,8 @@ async function createMariaDBModels(filesOrgPath: string, resultsPath: string): P
             user: process.env.MARIADB_Username,
             password: process.env.MARIADB_Password,
             databaseType: 'mariadb',
-            resultsPath: resultsPath
+            resultsPath: resultsPath,
+            convertCase: true
         });
 
 


### PR DESCRIPTION
I added a -c option to generate model using
- PascalCase for entities
- camelCase for properties
- kebab-case for filenames

I refactored the _imports_ section to facilitate using the optional casing using Handlebars helpers.
I cleaned up the formatting in the template to remove some whitespace.