### PR TITLE
Don't require password to be set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ var argv = Yargs
     .option('x', {
         alias: 'pass',
         describe: 'Password for database server.',
-        demand: true
+        default: ''
     })
     .option('p', {
         alias: 'port',


### PR DESCRIPTION
My local database doesn't have a password, passing an empty string like:

```
npx typeorm-model-generator -h 127.0.0.1 -d sketch_cloud_test -p 3306 -u root -x='' -e mariadb -o ./
```

Results in the following error:

```
[12:02:42] Starting creation of model classes.
/Users/timon/Projects/Personal/typeorm-model-generator/node_modules/mysql/lib/protocol/Parser.js:80
        throw err; // Rethrow non-MySQL errors
        ^

TypeError: First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.
    at Function.Buffer.from (buffer.js:198:9)
    at Object.Auth.token (/Users/timon/Projects/Personal/typeorm-model-generator/node_modules/mysql/lib/protocol/Auth.js:29:29)
    at Handshake._sendCredentials (/Users/timon/Projects/Personal/typeorm-model-generator/node_modules/mysql/lib/protocol/sequences/Handshake.js:105:14)
    at Handshake.HandshakeInitializationPacket (/Users/timon/Projects/Personal/typeorm-model-generator/node_modules/mysql/lib/protocol/sequences/Handshake.js:87:10)
    at Protocol._parsePacket (/Users/timon/Projects/Personal/typeorm-model-generator/node_modules/mysql/lib/protocol/Protocol.js:279:23)
    at Parser.write (/Users/timon/Projects/Personal/typeorm-model-generator/node_modules/mysql/lib/protocol/Parser.js:76:12)
    at Protocol.write (/Users/timon/Projects/Personal/typeorm-model-generator/node_modules/mysql/lib/protocol/Protocol.js:39:16)
    at Socket.<anonymous> (/Users/timon/Projects/Personal/typeorm-model-generator/node_modules/mysql/lib/Connection.js:103:28)
    at emitOne (events.js:115:13)
    at Socket.emit (events.js:210:7)
```

For some reason Yargs translates an empty string to `true`. I fixed this by not requiring the password to be passed and to default to an empty string.