### PR TITLE
Update README.md --output values

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,18 +51,18 @@ Options:
 * Creating model from local MSSQL database
    * Global module
       ```
-      typeorm-model-generator -h localhost -d tempdb -u sa -x !Passw0rd -e mssql -o .\
+      typeorm-model-generator -h localhost -d tempdb -u sa -x !Passw0rd -e mssql -o .
       ````
    * Npx Way
       ```
-      npx typeorm-model-generator -h localhost -d tempdb -u sa -x !Passw0rd -e mssql -o .\
+      npx typeorm-model-generator -h localhost -d tempdb -u sa -x !Passw0rd -e mssql -o .
       ````
 * Creating model from local Postgres database, public schema with ssl connection
    * Global module
       ```
-      typeorm-model-generator -h localhost -d postgres -u postgres -x !Passw0rd -e postgres -o .\ -s public --ssl
+      typeorm-model-generator -h localhost -d postgres -u postgres -x !Passw0rd -e postgres -o . -s public --ssl
       ````
    * Npx Way
       ```
-      npx typeorm-model-generator -h localhost -d postgres -u postgres -x !Passw0rd -e postgres -o .\ -s public --ssl
+      npx typeorm-model-generator -h localhost -d postgres -u postgres -x !Passw0rd -e postgres -o . -s public --ssl
       ````


### PR DESCRIPTION
On *nix  systems `\ ` will escape empty space from here `-o .\ -s public` and the result of this command will be not specifying schema, but creating a dot folder with name `. -s public` where entities are generated.
I have not tested this change on windows machine, where I guess the former syntax is perfectly OK, but I'm not sure for the latter.