### PR TITLE
Add --remove-id and --lazy; bugfix in @Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,21 @@ Usage: typeorm-model-generator -h <host> -d <database> -p [port] -u <user> -x
 [password] -e [engine]
 
 Options:
-  -h, --host      IP adress/Hostname for database server.             [required]
-  -d, --database  Database name.                                      [required]
-  -u, --user      Username for database server.                       [required]
-  -x, --pass      Password for database server.                       [required]
-  -p, --port      Port number for database server.
-  -e, --engine    Database engine.
+  --help                 Show help                                     [boolean]
+  --version              Show version number                           [boolean]
+  -h, --host             IP adress/Hostname for database server.      [required]
+  -d, --database         Database name.                               [required]
+  -u, --user             Username for database server.                [required]
+  -x, --pass             Password for database server.             [default: ""]
+  -p, --port             Port number for database server.
+  -e, --engine           Database engine.
            [choices: "mssql", "postgres", "mysql", "mariadb"] [default: "mssql"]
-  -o, --output    Where to place generated models.
-  -s, --schema    Schema name to create model from. Only for mssql and postgres.
+  -o, --output           Where to place generated models.
+                 [default: "/Users/bluepichu/git/zensors/typeorm-models/output"]
+  -s, --schema           Schema name to create model from. Only for mssql and
+                         postgres.
   --ssl                                               [boolean] [default: false]
-  --noConfig      Doesn't create tsconfig.json and ormconfig.json
+  --noConfig             Doesn't create tsconfig.json and ormconfig.json
                                                       [boolean] [default: false]
   --cf, --case-file      Convert file names to specified case
                  [choices: "pascal", "param", "camel", "none"] [default: "none"]
@@ -45,6 +49,9 @@ Options:
                           [choices: "pascal", "camel", "none"] [default: "none"]
   --cp, --case-property  Convert property names to specified case
                           [choices: "pascal", "camel", "none"] [default: "none"]
+  --ri, --remove-id      Remove _id suffix from fields          [default: false]
+  --lazy                 Use lazy loads between fields with relationsips
+                                                                [default: false]
 ```
 ### Examples
 

--- a/src/Engine.ts
+++ b/src/Engine.ts
@@ -124,6 +124,9 @@ export class Engine {
             }
             return retStr;
         });
+        Handlebars.registerHelper("array", str => str + "[]");
+        Handlebars.registerHelper("makeLazy", str => this.Options.lazy ? `Promise<${str}>` : str);
+        Handlebars.registerHelper("addLazyParameter", () => this.Options.lazy ? `, { lazy: true }` : "");
         Handlebars.registerHelper("toFileName", str => {
             let retStr = "";
             switch (this.Options.convertCaseFile) {
@@ -243,4 +246,5 @@ export interface EngineOptions {
     convertCaseEntity: "pascal" | "camel" | "none";
     convertCaseProperty: "pascal" | "camel" | "none";
     removeIdSuffix: boolean;
+    lazy: boolean;
 }

--- a/src/Engine.ts
+++ b/src/Engine.ts
@@ -144,6 +144,11 @@ export class Engine {
         });
         Handlebars.registerHelper("toPropertyName", str => {
             let retStr = "";
+
+            if (this.Options.removeIdSuffix && str.length > 3 && str.endsWith("_id")) {
+                str = str.substring(0, str.length - 3);
+            }
+
             switch (this.Options.convertCaseProperty) {
                 case "camel":
                     retStr = changeCase.camelCase(str);
@@ -237,4 +242,5 @@ export interface EngineOptions {
     convertCaseFile: "pascal" | "param" | "camel" | "none";
     convertCaseEntity: "pascal" | "camel" | "none";
     convertCaseProperty: "pascal" | "camel" | "none";
+    removeIdSuffix: boolean;
 }

--- a/src/entity.mst
+++ b/src/entity.mst
@@ -4,7 +4,7 @@ import {Index,Entity, PrimaryColumn, Column, OneToOne, OneToMany, ManyToOne, Joi
 
 
 @Entity("{{EntityName}}")
-{{#Indexes}}{{^isPrimaryKey}}@Index("{{name}}",[{{#columns}}"{{name}}",{{/columns}}]{{#isUnique}},{unique:true}{{/isUnique}})
+{{#Indexes}}{{^isPrimaryKey}}@Index("{{name}}",[{{#columns}}"{{toPropertyName name}}",{{/columns}}]{{#isUnique}},{unique:true}{{/isUnique}})
 {{/isPrimaryKey}}{{/Indexes}}export class {{toEntityName EntityName}} {
 {{#Columns}}
 

--- a/src/entity.mst
+++ b/src/entity.mst
@@ -20,12 +20,12 @@ import {Index,Entity, PrimaryColumn, Column, OneToOne, OneToMany, ManyToOne, Joi
         enum:[{{.}}],{{/enumOptions}}
         name:"{{name}}"
         })
-    {{toPropertyName name}}:{{ts_type}};
+    {{toPropertyName name}}: {{ts_type}};
         {{/relations}}{{#relations}}
-    @{{relationType}}(type=>{{toEntityName relatedTable}}, {{toPropertyName ../name}}=>{{toPropertyName ../name}}.{{#if isOwner}}{{toPropertyName ownerColumn}}{{else}}{{toPropertyName relatedColumn}}{{/if}}){{#isOwner}}
+    @{{relationType}}(type=>{{toEntityName relatedTable}}, {{toPropertyName ../name}}=>{{toPropertyName ../name}}.{{#if isOwner}}{{toPropertyName ownerColumn}}{{else}}{{toPropertyName relatedColumn}}{{/if}}{{addLazyParameter}}){{#isOwner}}
     @JoinColumn({ name:'{{ ../name}}'}){{/isOwner}}
-    {{#if isOneToMany}}{{toPropertyName ../name}}:{{toEntityName relatedTable}}[];
-    {{else}}{{toPropertyName ../name}}:{{toEntityName relatedTable}};
+    {{#if isOneToMany}}{{toPropertyName ../name}}: {{makeLazy (array (toEntityName relatedTable))}};
+    {{else}}{{toPropertyName ../name}}: {{makeLazy (toEntityName relatedTable)}};
     {{/if}}{{/relations}}
     {{/Columns}}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,11 @@ var argv = Yargs.usage(
         describe: "Convert property names to specified case",
         choices: ["pascal", "camel", "none"],
         default: "none"
+    })
+    .option("ri", {
+        alias: "remove-id",
+        describe: "Remove _id suffix from fields",
+        default: false
     }).argv;
 
 var driver: AbstractDriver;
@@ -124,7 +129,8 @@ let engine = new Engine(driver, {
     noConfigs: argv.noConfig,
     convertCaseFile: argv.cf,
     convertCaseEntity: argv.ce,
-    convertCaseProperty: argv.cp
+    convertCaseProperty: argv.cp,
+    removeIdSuffix: argv.ri
 });
 
 console.log(

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,10 @@ var argv = Yargs.usage(
         alias: "remove-id",
         describe: "Remove _id suffix from fields",
         default: false
+    })
+    .option("lazy", {
+        describe: "Use lazy loads between fields with relationsips",
+        default: false
     }).argv;
 
 var driver: AbstractDriver;
@@ -130,7 +134,8 @@ let engine = new Engine(driver, {
     convertCaseFile: argv.cf,
     convertCaseEntity: argv.ce,
     convertCaseProperty: argv.cp,
-    removeIdSuffix: argv.ri
+    removeIdSuffix: argv.ri,
+    lazy: argv.lazy
 });
 
 console.log(

--- a/test/utils/GeneralTestUtils.ts
+++ b/test/utils/GeneralTestUtils.ts
@@ -56,6 +56,7 @@ export async function createMSSQLModels(filesOrgPath: string, resultsPath: strin
             convertCaseFile: 'none',
             convertCaseProperty: 'none',
             removeIdSuffix: false,
+            lazy: false,
         });
 
 
@@ -104,6 +105,7 @@ export async function createPostgresModels(filesOrgPath: string, resultsPath: st
             convertCaseFile: 'none',
             convertCaseProperty: 'none',
             removeIdSuffix: false,
+            lazy: false,
         });
 
 
@@ -153,6 +155,7 @@ export async function createMysqlModels(filesOrgPath: string, resultsPath: strin
             convertCaseFile: 'none',
             convertCaseProperty: 'none',
             removeIdSuffix: false,
+            lazy: false,
         });
 
 
@@ -202,6 +205,7 @@ export async function createMariaDBModels(filesOrgPath: string, resultsPath: str
             convertCaseFile: 'none',
             convertCaseProperty: 'none',
             removeIdSuffix: false,
+            lazy: false,
         });
 
 
@@ -253,6 +257,7 @@ export async function createOracleDBModels(filesOrgPath: string, resultsPath: st
             convertCaseFile: 'none',
             convertCaseProperty: 'none',
             removeIdSuffix: false,
+            lazy: false,
         });
 
 

--- a/test/utils/GeneralTestUtils.ts
+++ b/test/utils/GeneralTestUtils.ts
@@ -55,6 +55,7 @@ export async function createMSSQLModels(filesOrgPath: string, resultsPath: strin
             convertCaseEntity: 'none',
             convertCaseFile: 'none',
             convertCaseProperty: 'none',
+            removeIdSuffix: false,
         });
 
 
@@ -102,6 +103,7 @@ export async function createPostgresModels(filesOrgPath: string, resultsPath: st
             convertCaseEntity: 'none',
             convertCaseFile: 'none',
             convertCaseProperty: 'none',
+            removeIdSuffix: false,
         });
 
 
@@ -150,6 +152,7 @@ export async function createMysqlModels(filesOrgPath: string, resultsPath: strin
             convertCaseEntity: 'none',
             convertCaseFile: 'none',
             convertCaseProperty: 'none',
+            removeIdSuffix: false,
         });
 
 
@@ -198,6 +201,7 @@ export async function createMariaDBModels(filesOrgPath: string, resultsPath: str
             convertCaseEntity: 'none',
             convertCaseFile: 'none',
             convertCaseProperty: 'none',
+            removeIdSuffix: false,
         });
 
 
@@ -248,7 +252,7 @@ export async function createOracleDBModels(filesOrgPath: string, resultsPath: st
             convertCaseEntity: 'none',
             convertCaseFile: 'none',
             convertCaseProperty: 'none',
-
+            removeIdSuffix: false,
         });
 
 


### PR DESCRIPTION
## New features

- `--ri / --remove-id`: removes an `_id` suffix from all fields (unless the entire field name is `_id`)

This is nice for fields that are relations; for example, if an entity `Post` references an entity `User` via a field `author_id`, the field to access the `User` entity is now `Post.author` instead of `Post.author_id` when the `--ri` flag is used.

- `--lazy`: emits lazy relations on all join fields

This essentially just adds `{ lazy: true }` to the relation decorator and changes the type from `T` to `Promise<T>` for all relation fields.

## Bugfixes

This PR also fixes a bug wherein the column names referenced in `@Index` did not match those in the generated models when `--cp` is used.