### PR TITLE
Definite assignment assertion modifier for latest typescript version

### DIFF
--- a/src/entity.mst
+++ b/src/entity.mst
@@ -22,12 +22,12 @@ import {Index,Entity, PrimaryColumn, Column, OneToOne, OneToMany, ManyToOne, Man
         enum:[{{.}}],{{/enumOptions}}
         name:"{{name}}"
         })
-    {{toPropertyName name}}:{{ts_type}};
+    {{toPropertyName name}}!:{{ts_type}};
         {{/relations}}{{#relations}}
     @{{relationType}}(type=>{{toEntityName relatedTable}}, {{toPropertyName ../name}}=>{{toPropertyName ../name}}.{{#if isOwner}}{{toPropertyName ownerColumn}},{ {{#../isPrimary}}primary:true,{{/../isPrimary}}{{^../is_nullable}} nullable:false,{{/../is_nullable}}{{#actionOnDelete}}onDelete: '{{.}}',{{/actionOnDelete}}{{#actionOnUpdate}}onUpdate: '{{.}}'{{/actionOnUpdate}} }{{else}}{{toPropertyName relatedColumn}}{{#actionOnDelete}},{ onDelete: '{{.}}' }{{/actionOnDelete}}{{/if}}){{#isOwner}}
     {{#if isManyToMany}}@JoinTable(){{else}}@JoinColumn({ name:'{{ ../name}}'}){{/if}}{{/isOwner}}
-    {{#if (or isOneToMany isManyToMany)}}{{toPropertyName ../name}}:{{toLazy (concat  (toEntityName relatedTable) "[]")}};
-    {{else}}{{toPropertyName ../name}}:{{toLazy (toEntityName relatedTable)}};
+    {{#if (or isOneToMany isManyToMany)}}{{toPropertyName ../name}}!:{{toLazy (concat  (toEntityName relatedTable) "[]")}};
+    {{else}}{{toPropertyName ../name}}!:{{toLazy (toEntityName relatedTable)}};
     {{/if}}{{/relations}}
     {{/Columns}}
     {{#if GenerateConstructor}}


### PR DESCRIPTION
In the latest typescript version, any property without a proper initializer will give an error something like:

> Property ‘name’ has no initializer and is not definitely assigned in the constructor.

So, I have added the "Definite assignment assertion modifier". So, that error will not occur on the properties.