### PR TITLE
 Current case-conv for class name in @RelationId

### DIFF
--- a/src/entity.mst
+++ b/src/entity.mst
@@ -32,7 +32,7 @@ import {BaseEntity,Column,Entity,Index,JoinColumn,JoinTable,ManyToMany,ManyToOne
     {{/if}}
     {{#if relationIdField }}
 
-    @RelationId(({{../../tsEntityName}}: {{../../tsEntityName}}) => {{../../tsEntityName}}.{{toPropertyName ../tsName}})
+    @RelationId(({{../../tsEntityName}}: {{toEntityName ../../tsEntityName}}) => {{../../tsEntityName}}.{{toPropertyName ../tsName}})
     {{toPropertyName ../tsName}}Id: {{#if isOneToOne}}{{toLazy ../tsType}}{{else}}{{toLazy (concat  ../tsType "[]")}}{{/if}};{{/if}}{{/relations}}
     {{/Columns}}
     {{#if GenerateConstructor}}


### PR DESCRIPTION
In @RelationId decorator generation class name must be case-converted according to current settings

P.S. Thanks for a great work!