### PR TITLE
"Object" to "object" for linting's sake

### DIFF
--- a/src/drivers/MysqlDriver.ts
+++ b/src/drivers/MysqlDriver.ts
@@ -163,7 +163,7 @@ export class MysqlDriver extends AbstractDriver {
                             ).replace(/\'/gi, '"');
                             break;
                         case "json":
-                            colInfo.tsType = "Object";
+                            colInfo.tsType = "object";
                             break;
                         case "binary":
                             colInfo.tsType = "Buffer";

--- a/src/drivers/PostgresDriver.ts
+++ b/src/drivers/PostgresDriver.ts
@@ -159,8 +159,8 @@ export class PostgresDriver extends AbstractDriver {
                 | "boolean"
                 | "Date"
                 | "Buffer"
-                | "Object"
-                | "string | Object"
+                | "object"
+                | "string | object"
                 | "string | string[]"
                 | "any"
                 | null;
@@ -288,7 +288,7 @@ export class PostgresDriver extends AbstractDriver {
                 ret.ts_type = "string";
                 break;
             case "point":
-                ret.ts_type = "string | Object";
+                ret.ts_type = "string | object";
                 break;
             case "line":
                 ret.ts_type = "string";
@@ -297,7 +297,7 @@ export class PostgresDriver extends AbstractDriver {
                 ret.ts_type = "string | string[]";
                 break;
             case "box":
-                ret.ts_type = "string | Object";
+                ret.ts_type = "string | object";
                 break;
             case "path":
                 ret.ts_type = "string";
@@ -306,7 +306,7 @@ export class PostgresDriver extends AbstractDriver {
                 ret.ts_type = "string";
                 break;
             case "circle":
-                ret.ts_type = "string | Object";
+                ret.ts_type = "string | object";
                 break;
             case "cidr":
                 ret.ts_type = "string";
@@ -330,10 +330,10 @@ export class PostgresDriver extends AbstractDriver {
                 ret.ts_type = "string";
                 break;
             case "json":
-                ret.ts_type = "Object";
+                ret.ts_type = "object";
                 break;
             case "jsonb":
-                ret.ts_type = "Object";
+                ret.ts_type = "object";
                 break;
             case "int4range":
                 ret.ts_type = "string";

--- a/src/models/ColumnInfo.ts
+++ b/src/models/ColumnInfo.ts
@@ -10,8 +10,8 @@ export class ColumnInfo {
         | "boolean"
         | "Date"
         | "Buffer"
-        | "Object"
-        | "string | Object"
+        | "object"
+        | "string | object"
         | "string | string[]"
         | "any";
     public relations: RelationInfo[] = [];

--- a/test/integration/entityTypes/mariadb/entity/Post.ts
+++ b/test/integration/entityTypes/mariadb/entity/Post.ts
@@ -89,7 +89,7 @@ export class Post {
 
     // In mariaDb Json is recognized as longtext
     // @Column("json")
-    // json: Object;
+    // json: object;
 
     @Column("binary")
     binary: Buffer;

--- a/test/integration/entityTypes/mysql/entity/Post.ts
+++ b/test/integration/entityTypes/mysql/entity/Post.ts
@@ -88,7 +88,7 @@ export class Post {
     enum: string;
 
     @Column("json")
-    json: Object;
+    json: object;
 
     @Column("binary")
     binary: Buffer;

--- a/test/integration/entityTypes/postgres/entity/Post.ts
+++ b/test/integration/entityTypes/postgres/entity/Post.ts
@@ -165,10 +165,10 @@ export class Post {
     xml: string;
 
     @Column("json")
-    json: Object;
+    json: object;
 
     @Column("jsonb")
-    jsonb: Object;
+    jsonb: object;
 
     @Column("int4range")
     int4range: string;

--- a/test/integration/entityTypes/postgres/entity/Post.ts
+++ b/test/integration/entityTypes/postgres/entity/Post.ts
@@ -123,7 +123,7 @@ export class Post {
     // enum: string;
 
     @Column("point")
-    point: string | Object;
+    point: string | object;
 
     @Column("line")
     line: string;
@@ -132,7 +132,7 @@ export class Post {
     lseg: string | string[];
 
     @Column("box")
-    box: string | Object;
+    box: string | object;
 
     @Column("path")
     path: string;
@@ -141,7 +141,7 @@ export class Post {
     polygon: string;
 
     @Column("circle")
-    circle: string | Object;
+    circle: string | object;
 
     @Column("cidr")
     cidr: string;

--- a/test/integration/entityTypes/postgres/entity/PostArrays.ts
+++ b/test/integration/entityTypes/postgres/entity/PostArrays.ts
@@ -123,7 +123,7 @@ export class PostArrays {
     // enum: string[];
 
     @Column("point", { array: true })
-    point: string[] | Object[];
+    point: string[] | object[];
 
     @Column("line", { array: true })
     line: string[];
@@ -132,7 +132,7 @@ export class PostArrays {
     lseg: string[] | string[][];
 
     @Column("box", { array: true })
-    box: string[] | Object[];
+    box: string[] | object[];
 
     @Column("path", { array: true })
     path: string[];
@@ -141,7 +141,7 @@ export class PostArrays {
     polygon: string[];
 
     @Column("circle", { array: true })
-    circle: string[] | Object[];
+    circle: string[] | object[];
 
     @Column("cidr", { array: true })
     cidr: string[];
@@ -165,10 +165,10 @@ export class PostArrays {
     xml: string[];
 
     @Column("json", { array: true })
-    json: Object[];
+    json: object[];
 
     @Column("jsonb", { array: true })
-    jsonb: Object[];
+    jsonb: object[];
 
     @Column("int4range", { array: true })
     int4range: string[];


### PR DESCRIPTION
Replaced "Object" with "object" for the generated JSON column type, so that TSLint does not complain about it being too general, while still preserving the same semantics.

This does mean the produced code requires TypeScript 2.2 at minimum, but the TypeScript ecosystem moves fast enough that this is already a very old version, so it's fine.