### PR TITLE
Disable composite intersecting keys, even on many-to-many relations

### DIFF
--- a/src/drivers/AbstractDriver.ts
+++ b/src/drivers/AbstractDriver.ts
@@ -225,7 +225,14 @@ export default abstract class AbstractDriver {
                     relationTmp.ownerColumnsNames.length * 2
                 ) {
                     TomgUtils.LogError(
-                        `Relation between tables ${relationTmp.ownerTable} and ${relationTmp.referencedTable} wasn't generated correctly - complex relationships aren't supported yet.`
+                        `Relation between tables ${
+                            relationTmp.ownerTable
+                        }.(${relationTmp.ownerColumnsNames.join(",")}) and ${
+                            relationTmp.referencedTable
+                        }.(${relationTmp.referencedColumnsNames.join(
+                            ","
+                        )}) wasn't generated correctly - complex relationships aren't supported yet.`,
+                        false
                     );
                     return;
                 }
@@ -237,7 +244,38 @@ export default abstract class AbstractDriver {
                 )!;
                 if (!secondRelation) {
                     TomgUtils.LogError(
-                        `Relation between tables ${relationTmp.ownerTable} and ${relationTmp.referencedTable} wasn't generated correctly - complex relationships aren't supported yet.`
+                        `Relation between tables ${
+                            relationTmp.ownerTable
+                        }.(${relationTmp.ownerColumnsNames.join(",")}) and ${
+                            relationTmp.referencedTable
+                        }.(${relationTmp.referencedColumnsNames.join(
+                            ","
+                        )}) wasn't generated correctly - complex relationships aren't supported yet.`,
+                        false
+                    );
+                    return;
+                }
+                const intersectingRelation = relationsTemp.find(
+                    (relation: RelationTempInfo) =>
+                        relation !== relationTmp &&
+                        relation.ownerTable === relationTmp.ownerTable &&
+                        relation.referencedTable !==
+                            relationTmp.referencedTable &&
+                        relation.ownerColumnsNames.filter(
+                            (c: string) =>
+                                relationTmp.ownerColumnsNames.indexOf(c) !== -1
+                        ).length > 0
+                );
+                if (intersectingRelation) {
+                    TomgUtils.LogError(
+                        `Relation between tables ${
+                            relationTmp.ownerTable
+                        }.(${relationTmp.ownerColumnsNames.join(",")}) and ${
+                            relationTmp.referencedTable
+                        }.(${relationTmp.referencedColumnsNames.join(
+                            ","
+                        )}) wasn't generated correctly - complex relationships aren't supported yet.`,
+                        false
                     );
                     return;
                 }

--- a/src/drivers/MysqlDriver.ts
+++ b/src/drivers/MysqlDriver.ts
@@ -267,7 +267,8 @@ export default class MysqlDriver extends AbstractDriver {
             FROM information_schema.statistics sta
             WHERE table_schema IN (${MysqlDriver.escapeCommaSeparatedList(
                 dbNames
-            )})`);
+            )})
+            ORDER BY TableName, IndexName, SEQ_IN_INDEX`);
         entities.forEach(ent => {
             response
                 .filter(filterVal => filterVal.TableName === ent.tsEntityName)
@@ -327,7 +328,8 @@ export default class MysqlDriver extends AbstractDriver {
                 ON CU.CONSTRAINT_NAME=RC.CONSTRAINT_NAME AND CU.CONSTRAINT_SCHEMA = RC.CONSTRAINT_SCHEMA
           WHERE
             TABLE_SCHEMA IN (${MysqlDriver.escapeCommaSeparatedList(dbNames)})
-            AND CU.REFERENCED_TABLE_NAME IS NOT NULL;
+            AND CU.REFERENCED_TABLE_NAME IS NOT NULL
+          ORDER BY object_id, FK_PartNo;
             `);
         const relationsTemp: RelationTempInfo[] = [] as RelationTempInfo[];
         response.forEach(resp => {


### PR DESCRIPTION
As mentioned in the last comment of #190 , multiple composite keys that that are otherwise many-to-many are not properly generated either, but result in duplicate properties instead. This PR disables them.

Also, I've refactored the error messages a bit, to include the list of affected column names (to better inform the user which foreign key exactly isn't being generated), and have added isABug: false, since this isn't really the kind of error you want a trace for.