### PR TITLE
Fix for: Argument of type '{ type: "int"; unique: boolean; name: string; }' is not assignable to parameter of type 'PrimaryGeneratedColumnNumericOptions'.

### DIFF
--- a/src/entity.mst
+++ b/src/entity.mst
@@ -12,8 +12,8 @@ import {BaseEntity,Column,Entity,Index,JoinColumn,JoinTable,ManyToMany,ManyToOne
         type:"{{type}}", {{/generated}}{{^generated}} @Column("{{type}}",{ {{#nullable}}
         nullable:true,{{/nullable}}{{^nullable}}
         nullable:false,{{/nullable}}{{#primary}}
-        primary:{{primary}},{{/primary}}{{/generated}}{{#unique}}
-        unique: true,{{/unique}}{{#length}}
+        primary:{{primary}},{{/primary}}{{#unique}}
+        unique: true,{{/unique}}{{/generated}}{{#length}}
         length:{{.}},{{/length}}{{#width}}
         width:{{.}},{{/width}}{{#unsigned}}
         unsigned: true,{{/unsigned}}{{#default}}


### PR DESCRIPTION
Fix for:
Argument of type '{ type: "int"; unique: boolean; name: string; }' is not assignable to parameter of type 'PrimaryGeneratedColumnNumericOptions'.