### PR TITLE
Made relation IDs not be generated for OneToOne relations, and instea…

### DIFF
--- a/src/Engine.ts
+++ b/src/Engine.ts
@@ -162,7 +162,7 @@ function setRelationId(
         model.forEach(ent => {
             ent.Columns.forEach(col => {
                 col.relations.forEach(rel => {
-                    rel.relationIdField = rel.isOwner;
+                    rel.relationIdField = rel.isOwner && !rel.isOneToOne;
                 });
             });
         });

--- a/src/drivers/AbstractDriver.ts
+++ b/src/drivers/AbstractDriver.ts
@@ -367,6 +367,20 @@ export default abstract class AbstractDriver {
                     referencedRelation.ownerColumn = relatedColumn.tsName;
                     referencedRelation.relationType = "OneToOne";
                     referencedEntity.Columns.push(col);
+
+                    const idCol = new ColumnInfo();
+                    idCol.options = ownerColumn.options;
+                    idCol.tsType = ownerColumn.tsType;
+                    idCol.tsName = ownerColumn.options.name!;
+                    ownerEntity.Columns.splice(
+                        1 +
+                            ownerEntity.Columns.findIndex(
+                                (candidate: ColumnInfo) =>
+                                    candidate === ownerColumn
+                            ),
+                        0,
+                        idCol
+                    );
                 }
             }
         });


### PR DESCRIPTION
Made relation IDs not be generated for OneToOne relations, and instead, a normal column is generated regardless of relation ID setting.

This is my attempt at solving #217. Like I said there, I don't know if this is the right thing to do... But it works.

I think a better solution would be to generate both an eager ```@RelationId``` and a ```@Column```, but doing that is far trickier than this solution.