### PR TITLE
Add joinColumn and inverseJoinColumn to @JoinTable properties (fixes #183)

### DIFF
--- a/src/drivers/AbstractDriver.ts
+++ b/src/drivers/AbstractDriver.ts
@@ -91,10 +91,15 @@ export default abstract class AbstractDriver {
         );
         manyToManyEntities.forEach(entity => {
             let relations: RelationInfo[] = [];
-            relations = entity.Columns.reduce(
-                (prev: RelationInfo[], curr) => prev.concat(curr.relations),
-                relations
-            );
+            const joinColumnMap = new Map<string, string>();
+
+            entity.Columns.forEach(column => {
+                column.relations.forEach(relation => {
+                    joinColumnMap.set(relation.relatedTable, column.tsName);
+                    relations.push(relation);
+                });
+            });
+
             const namesOfRelatedTables = relations
                 .map(v => v.relatedTable)
                 .filter((v, i, s) => s.indexOf(v) === i);
@@ -138,6 +143,11 @@ export default abstract class AbstractDriver {
                 col1Rel.isOwner = true;
                 col1Rel.ownerColumn = firstRelatedTable;
 
+                col1Rel.joinColumn = joinColumnMap.get(namesOfRelatedTables[0]);
+                col1Rel.inverseJoinColumn = joinColumnMap.get(
+                    namesOfRelatedTables[1]
+                );
+
                 column1.relations.push(col1Rel);
                 relatedTable1.Columns.push(column1);
 
@@ -147,6 +157,11 @@ export default abstract class AbstractDriver {
                 const col2Rel = new RelationInfo();
                 col2Rel.relatedTable = firstRelatedTable;
                 col2Rel.relatedColumn = secondRelatedTable;
+
+                col2Rel.joinColumn = joinColumnMap.get(namesOfRelatedTables[1]);
+                col2Rel.inverseJoinColumn = joinColumnMap.get(
+                    namesOfRelatedTables[0]
+                );
 
                 col2Rel.relationType = "ManyToMany";
                 col2Rel.isOwner = false;

--- a/src/drivers/AbstractDriver.ts
+++ b/src/drivers/AbstractDriver.ts
@@ -90,7 +90,7 @@ export default abstract class AbstractDriver {
                 }).length === entity.Columns.length
         );
         manyToManyEntities.forEach(entity => {
-            let relations: RelationInfo[] = [];
+            const relations: RelationInfo[] = [];
             const joinColumnMap = new Map<string, string>();
 
             entity.Columns.forEach(column => {

--- a/src/entity.mst
+++ b/src/entity.mst
@@ -27,7 +27,7 @@ import {BaseEntity,Column,Entity,Index,JoinColumn,JoinTable,ManyToMany,ManyToOne
     {{printPropertyVisibility}}{{toPropertyName tsName}}{{strictMode}}:{{tsType}}{{#options/nullable}} | null{{/options/nullable}};
         {{/relations}}{{#relations}}
     @{{relationType}}(()=>{{toEntityName relatedTable}}, ({{toPropertyName relatedTable}}: {{toEntityName relatedTable}})=>{{toPropertyName relatedTable}}.{{#if isOwner}}{{toPropertyName ownerColumn}},{ {{#../options/primary}}primary:true,{{/../options/primary}}{{^../options/nullable}} nullable:false,{{/../options/nullable}}{{#actionOnDelete}}onDelete: '{{.}}',{{/actionOnDelete}}{{#actionOnUpdate}}onUpdate: '{{.}}'{{/actionOnUpdate}} }{{else}}{{toPropertyName relatedColumn}}{{#if (or actionOnDelete actionOnUpdate ) }},{ {{#actionOnDelete}}onDelete: '{{.}}' ,{{/actionOnDelete}}{{#actionOnUpdate}}onUpdate: '{{.}}'{{/actionOnUpdate}} }{{/if}}{{/if}}){{#isOwner}}
-    {{#if isManyToMany}}@JoinTable({ name:'{{ ../options/name}}'}){{else}}@JoinColumn({ name:'{{ ../options/name}}'}){{/if}}{{/isOwner}}
+    {{#if isManyToMany}}@JoinTable({ name:'{{ ../options/name}}'{{#if joinColumn}},joinColumn:{name:'{{joinColumn}}'}{{/if}}{{#if inverseJoinColumn}},inverseJoinColumn:{name:'{{inverseJoinColumn}}'}{{/if}} }){{else}}@JoinColumn({ name:'{{ ../options/name}}'}){{/if}}{{/isOwner}}
     {{#if (or isOneToMany isManyToMany)}}{{printPropertyVisibility}}{{toPropertyName ../tsName}}{{strictMode}}:{{toLazy (concat  (toEntityName relatedTable) "[]")}};
     {{else}}{{printPropertyVisibility}}{{toPropertyName ../tsName}}{{strictMode}}:{{toLazy (concat (toEntityName relatedTable) ' | null')}};
     {{/if}}

--- a/src/models/RelationInfo.ts
+++ b/src/models/RelationInfo.ts
@@ -11,6 +11,10 @@ export default class RelationInfo {
 
     public ownerColumn: string;
 
+    public joinColumn?: string;
+
+    public inverseJoinColumn?: string;
+
     public actionOnDelete:
         | "RESTRICT"
         | "CASCADE"


### PR DESCRIPTION
This fixes issue #183.

I'm not entirely sure if `tsName` is the right column property to reference, but this worked for our setup, where database tables and columns use `underscored_names` convention.