### PR TITLE
Typeroots (in "next")

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "bin": "bin/typeorm-model-generator",
   "scripts": {
     "start": "ts-node ./src/index.ts",
-    "build": "npm run clean && tsc && ncp src/templates/ dist/src/templates/",
+    "build": "npm run clean && tsc && ncp src/templates/ dist/src/templates/ && ncp package.json dist/package.json",
     "prepare": "npm run build",
     "pretest": "tsc --noEmit",
     "test": "nyc --reporter=lcov ts-node ./node_modules/mocha/bin/_mocha test/**/*.test.ts  -- --bail",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,9 @@
         "lib": [
             "es2019","es2019.array"
         ],
+        "typeRoots": [
+          "./node_modules/@types"
+        ],
         "resolveJsonModule": true,
     },
     "include": [


### PR DESCRIPTION
Although this problem has existed in a long while, I only found a solution when playing around with the "next" branch, so since it's tested there, I'm basing the PR against it.

When installing this package as a dependency with yarn, it complains about duplicated declaration if there's any package that uses a test runner other than mocha. In my case Jest. The solution is to explicitly specify this package's ```./node_modules/@types``` into ```typeRoots```, so that tsc doesn't try to merge this pacakge's types with the including package's types.

Also, it seems npm adds package.json into dist after "prepare" for some reason (honestly, I don't understand what's the rule there...), but yarn doesn't. Since this package relies on package.json being there, I've also added an explicit ncp call for it. I don't know if npm replaces that file or not, but either way, it works without errors or warnings.