### PR TITLE
Proper typing and join on related relations (for "next")

### DIFF
--- a/src/ModelCustomization.ts
+++ b/src/ModelCustomization.ts
@@ -224,7 +224,9 @@ function addImportsAndGenerationOptions(
                 if (!relation.relationOptions) {
                     relation.relationOptions = {};
                 }
-                relation.relationOptions.lazy = true;
+                if (typeof relation.relationOptions.lazy === "undefined") {
+                    relation.relationOptions.lazy = true;
+                }
             }
         });
         if (generationOptions.skipSchema) {

--- a/src/ModelGeneration.ts
+++ b/src/ModelGeneration.ts
@@ -3,6 +3,7 @@ import * as Prettier from "prettier";
 import * as changeCase from "change-case";
 import * as fs from "fs";
 import * as path from "path";
+import { RelationOptions } from "typeorm";
 import IConnectionOptions from "./IConnectionOptions";
 import IGenerationOptions from "./IGenerationOptions";
 import { Entity } from "./models/Entity";
@@ -200,12 +201,16 @@ function createHandlebarsHelpers(generationOptions: IGenerationOptions): void {
     });
     Handlebars.registerHelper(
         "toRelation",
-        (entityType: string, relationType: Relation["relationType"]) => {
+        (
+            entityType: string,
+            relationType: Relation["relationType"],
+            relationOptions: RelationOptions
+        ) => {
             let retVal = entityType;
             if (relationType === "ManyToMany" || relationType === "OneToMany") {
                 retVal = `${retVal}[]`;
             }
-            if (generationOptions.lazy) {
+            if (relationOptions.lazy) {
                 retVal = `Promise<${retVal}>`;
             }
             return retVal;

--- a/src/drivers/AbstractDriver.ts
+++ b/src/drivers/AbstractDriver.ts
@@ -165,8 +165,10 @@ export default abstract class AbstractDriver {
                 firstRelation.joinTableOptions.schema = junctionEntity.schema;
             }
 
-            firstRelation.relationOptions = undefined;
-            secondRelation.relationOptions = undefined;
+            firstRelation.relationOptions = {};
+            secondRelation.relationOptions = {};
+            firstRelation.relatedFieldOptions = secondRelation.relationOptions;
+            secondRelation.relatedFieldOptions = firstRelation.relationOptions;
             firstRelation.joinColumnOptions = undefined;
             secondRelation.joinColumnOptions = undefined;
             retVal = retVal.filter(ent => {
@@ -350,15 +352,17 @@ export default abstract class AbstractDriver {
                 relatedTable: relationTmp.relatedTable.tscName,
                 relationType: isOneToMany ? "ManyToOne" : "OneToOne"
             };
-            if (JSON.stringify(relationOptions) !== "{}") {
-                ownerRelation.relationOptions = relationOptions;
-            }
+            ownerRelation.relationOptions =
+                JSON.stringify(relationOptions) !== "{}" ? relationOptions : {};
             const relatedRelation: Relation = {
                 fieldName: ownerRelation.relatedField,
+                relationOptions: {},
+                relatedFieldOptions: ownerRelation.relationOptions,
                 relatedField: ownerRelation.fieldName,
                 relatedTable: relationTmp.ownerTable.tscName,
                 relationType: isOneToMany ? "OneToMany" : "OneToOne"
             };
+            ownerRelation.relatedFieldOptions = relatedRelation.relationOptions;
 
             ownerEntity.relations.push(ownerRelation);
             relationTmp.relatedTable.relations.push(relatedRelation);
@@ -383,6 +387,7 @@ export default abstract class AbstractDriver {
                 ownerEntity.relationIds.push({
                     fieldName: relationIdFieldName,
                     fieldType,
+                    relationOptions: ownerRelation.relationOptions,
                     relationField: ownerRelation.fieldName
                 });
                 // TODO: RelationId on ManyToMany

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,10 +50,9 @@ function validateConfig(options: options): options {
         options.generationOptions.relationIds
     ) {
         TomgUtils.LogError(
-            "Typeorm doesn't support RelationId fields for lazy relations.",
+            "Typeorm doesn't support RelationId fields for lazy relations. RelationId will not be generated",
             false
         );
-        options.generationOptions.relationIds = false;
     }
     return options;
 }

--- a/src/models/Relation.ts
+++ b/src/models/Relation.ts
@@ -7,6 +7,7 @@ export type Relation = {
     relatedField: string;
     fieldName: string;
     relationOptions?: RelationOptions;
+    relatedFieldOptions?: RelationOptions;
     joinColumnOptions?: Required<JoinColumnOptions>[];
     joinTableOptions?: JoinTableMultipleColumnsOptions;
 };

--- a/src/models/RelationId.ts
+++ b/src/models/RelationId.ts
@@ -1,5 +1,8 @@
+import { RelationOptions } from "typeorm";
+
 export type RelationId = {
     fieldName: string;
     fieldType: string;
+    relationOptions?: RelationOptions;
     relationField: string;
 };

--- a/src/templates/entity.mst
+++ b/src/templates/entity.mst
@@ -13,17 +13,20 @@ import {{localImport (toEntityName .)}} from './{{toFileName .}}'
 { name: "{{name}}", referencedColumnName: "{{toPropertyName referencedColumnName}}" },
 {{/inline}}
 {{#*inline "Relation"}}
-@{{relationType}}(()=>{{toEntityName relatedTable}},{{toPropertyName relatedTable}}=>{{toPropertyName relatedTable}}.{{toPropertyName relatedField}}{{#if relationOptions}},{ {{json relationOptions}} }{{/if}})
+@{{relationType}}(() =>{{toEntityName relatedTable}},{{#if relatedFieldOptions.lazy}}async {{/if}}({{toPropertyName relatedTable}}: {{toEntityName relatedTable}}) =>{{toPropertyName relatedTable}}.{{toPropertyName relatedField}}{{#if relationOptions}},{ {{json relationOptions}} }{{/if}})
 {{#if joinColumnOptions}}@JoinColumn([{{#joinColumnOptions}}{{> JoinColumnOptions}}{{/joinColumnOptions}}]){{/if}}
 {{#joinTableOptions}}@JoinTable({ name:"{{name}}", joinColumns:[{{#joinColumns}}{{> JoinColumnOptions}}{{/joinColumns}}],inverseJoinColumns:[{{#inverseJoinColumns}}{{> JoinColumnOptions}}{{/inverseJoinColumns}}],{{#database}}database:"{{.}}",{{/database}}{{#schema}}schema:"{{.}}"{{/schema}} }){{/joinTableOptions}}
-{{printPropertyVisibility}}{{toPropertyName fieldName}}{{strictMode}}:{{toRelation (toEntityName relatedTable) relationType}};
+{{printPropertyVisibility}}{{toPropertyName fieldName}}{{strictMode}}:{{toRelation (toEntityName relatedTable) relationType relationOptions}};
 
 {{/inline}}
-{{#*inline "RelationId"}}
-@RelationId(({{toPropertyName entityName}}:{{toEntityName entityName}})=>{{toPropertyName entityName}}.{{toPropertyName relationField}})
+{{#*inline "RelationId"}}{{#unless relationOptions.lazy}}{{!
+  TypeORM doesn't support relationId from lazy relations right now.
+  However, once it does, the above check and this comment can simply be removed to add support in the generator.
+}}
+@RelationId({{#if relationOptions.lazy}}async {{/if}}({{toPropertyName entityName}}:{{toEntityName entityName}})=>{{toPropertyName entityName}}.{{toPropertyName relationField}})
 {{printPropertyVisibility}}{{toPropertyName fieldName}}{{strictMode}}:{{fieldType}};
 
-{{/inline}}
+{{/unless}}{{/inline}}
 {{#*inline "Constructor"}}
 {{printPropertyVisibility}}constructor(init?: Partial<{{toEntityName entityName}}>) {
     {{#activeRecord}}super();


### PR DESCRIPTION
The generated OneToMany relations and one side of OneToOne relations don't get JoinColumn options, making the generated entities invalid at runtime.

This fixes that, and also, there's a missing typedef for the argument on the inverse side of relations. And tslint complaints about promises having to be returned only by async functions, so that's also added based on the target's lazy option.

I realize a simpler approach might've been to take the overall generation option, but this approach also allows a custom naming strategy to make individual relations eager or lazy regardless of the global setting (which would really be just the default).

EDIT: Tests are failing, I'm guessing primarily due to the introduction of "async"... That seems to be tripping up the EntityFileToJson class... I'm not sure how to fix it though.