### PR TITLE
Null in TS types (for "next")

### DIFF
--- a/src/drivers/AbstractDriver.ts
+++ b/src/drivers/AbstractDriver.ts
@@ -376,11 +376,19 @@ export default abstract class AbstractDriver {
                     ownerColumns[0].tscName,
                     ownerEntity
                 );
+                let relationIdType = ownerColumns[0].tscType;
+                if (ownerColumns[0].options.nullable) {
+                    relationIdType += " | null";
+                }
                 ownerEntity.relationIds.push({
                     fieldName: relationIdFieldName,
                     fieldType: isOneToMany
-                        ? `${ownerColumns[0].tscType}[]`
-                        : ownerColumns[0].tscType,
+                        ? `${
+                              relationIdType.includes(" ")
+                                  ? `(${relationIdType})`
+                                  : relationIdType
+                          }[]`
+                        : relationIdType,
                     relationField: ownerRelation.fieldName
                 });
                 // TODO: RelationId on ManyToMany

--- a/src/drivers/AbstractDriver.ts
+++ b/src/drivers/AbstractDriver.ts
@@ -376,19 +376,20 @@ export default abstract class AbstractDriver {
                     ownerColumns[0].tscName,
                     ownerEntity
                 );
-                let relationIdType = ownerColumns[0].tscType;
-                if (ownerColumns[0].options.nullable) {
-                    relationIdType += " | null";
+
+                let fieldType = "";
+                if (isOneToMany) {
+                    fieldType = `${ownerColumns[0].tscType}[]`;
+                } else {
+                    fieldType = ownerColumns[0].tscType;
+                    if (ownerColumns[0].options.nullable) {
+                        fieldType += " | null";
+                    }
                 }
+
                 ownerEntity.relationIds.push({
                     fieldName: relationIdFieldName,
-                    fieldType: isOneToMany
-                        ? `${
-                              relationIdType.includes(" ")
-                                  ? `(${relationIdType})`
-                                  : relationIdType
-                          }[]`
-                        : relationIdType,
+                    fieldType,
                     relationField: ownerRelation.fieldName
                 });
                 // TODO: RelationId on ManyToMany

--- a/src/drivers/MssqlDriver.ts
+++ b/src/drivers/MssqlDriver.ts
@@ -90,7 +90,7 @@ WHERE TABLE_TYPE='BASE TABLE' and TABLE_SCHEMA in (${schema}) AND TABLE_CATALOG 
                         resp.COLUMN_DEFAULT
                     );
                     const columnType = resp.DATA_TYPE;
-                    let tscType = "";
+                    let tscType = "NonNullable<unknown>";
                     switch (resp.DATA_TYPE) {
                         case "bigint":
                             tscType = "string";

--- a/src/drivers/MssqlDriver.ts
+++ b/src/drivers/MssqlDriver.ts
@@ -90,7 +90,7 @@ WHERE TABLE_TYPE='BASE TABLE' and TABLE_SCHEMA in (${schema}) AND TABLE_CATALOG 
                         resp.COLUMN_DEFAULT
                     );
                     const columnType = resp.DATA_TYPE;
-                    let tscType = "NonNullable<unknown>";
+                    let tscType = "";
                     switch (resp.DATA_TYPE) {
                         case "bigint":
                             tscType = "string";
@@ -192,6 +192,7 @@ WHERE TABLE_TYPE='BASE TABLE' and TABLE_SCHEMA in (${schema}) AND TABLE_CATALOG 
                             tscType = "string";
                             break;
                         default:
+                            tscType = "NonNullable<unknown>";
                             TomgUtils.LogError(
                                 `Unknown column type: ${resp.DATA_TYPE}  table name: ${resp.TABLE_NAME} column name: ${resp.COLUMN_NAME}`
                             );
@@ -218,17 +219,14 @@ WHERE TABLE_TYPE='BASE TABLE' and TABLE_SCHEMA in (${schema}) AND TABLE_CATALOG 
                                 ? resp.CHARACTER_MAXIMUM_LENGTH
                                 : undefined;
                     }
-
-                    if (columnType) {
-                        ent.columns.push({
-                            generated,
-                            type: columnType,
-                            default: defaultValue,
-                            options,
-                            tscName,
-                            tscType
-                        });
-                    }
+                    ent.columns.push({
+                        generated,
+                        type: columnType,
+                        default: defaultValue,
+                        options,
+                        tscName,
+                        tscType
+                    });
                 });
         });
         return entities;

--- a/src/drivers/MysqlDriver.ts
+++ b/src/drivers/MysqlDriver.ts
@@ -69,7 +69,7 @@ export default class MysqlDriver extends AbstractDriver {
                 .filter(filterVal => filterVal.TABLE_NAME === ent.tscName)
                 .forEach(resp => {
                     const tscName = resp.COLUMN_NAME;
-                    let tscType = "";
+                    let tscType = "NonNullable<unknown>";
                     const options: Column["options"] = {
                         name: resp.COLUMN_NAME
                     };

--- a/src/drivers/MysqlDriver.ts
+++ b/src/drivers/MysqlDriver.ts
@@ -69,7 +69,7 @@ export default class MysqlDriver extends AbstractDriver {
                 .filter(filterVal => filterVal.TABLE_NAME === ent.tscName)
                 .forEach(resp => {
                     const tscName = resp.COLUMN_NAME;
-                    let tscType = "NonNullable<unknown>";
+                    let tscType = "";
                     const options: Column["options"] = {
                         name: resp.COLUMN_NAME
                     };
@@ -214,6 +214,7 @@ export default class MysqlDriver extends AbstractDriver {
                             tscType = "string";
                             break;
                         default:
+                            tscType = "NonNullable<unknown>";
                             TomgUtils.LogError(
                                 `Unknown column type: ${resp.DATA_TYPE}  table name: ${resp.TABLE_NAME} column name: ${resp.COLUMN_NAME}`
                             );
@@ -250,16 +251,14 @@ export default class MysqlDriver extends AbstractDriver {
                                 : undefined;
                     }
 
-                    if (columnType) {
-                        ent.columns.push({
-                            generated,
-                            type: columnType,
-                            default: defaultValue,
-                            options,
-                            tscName,
-                            tscType
-                        });
-                    }
+                    ent.columns.push({
+                        generated,
+                        type: columnType,
+                        default: defaultValue,
+                        options,
+                        tscName,
+                        tscType
+                    });
                 });
         });
         return entities;

--- a/src/drivers/OracleDriver.ts
+++ b/src/drivers/OracleDriver.ts
@@ -87,7 +87,7 @@ export default class OracleDriver extends AbstractDriver {
                               );
                     const DATA_TYPE = resp.DATA_TYPE.replace(/\([0-9]+\)/g, "");
                     const columnType = DATA_TYPE.toLowerCase();
-                    let tscType = "";
+                    let tscType = "NonNullable<unknown>";
                     switch (DATA_TYPE.toLowerCase()) {
                         case "char":
                             tscType = "string";

--- a/src/drivers/OracleDriver.ts
+++ b/src/drivers/OracleDriver.ts
@@ -87,7 +87,7 @@ export default class OracleDriver extends AbstractDriver {
                               );
                     const DATA_TYPE = resp.DATA_TYPE.replace(/\([0-9]+\)/g, "");
                     const columnType = DATA_TYPE.toLowerCase();
-                    let tscType = "NonNullable<unknown>";
+                    let tscType = "";
                     switch (DATA_TYPE.toLowerCase()) {
                         case "char":
                             tscType = "string";
@@ -177,6 +177,7 @@ export default class OracleDriver extends AbstractDriver {
                             tscType = "number";
                             break;
                         default:
+                            tscType = "NonNullable<unknown>";
                             TomgUtils.LogError(
                                 `Unknown column type:${DATA_TYPE}`
                             );
@@ -201,16 +202,14 @@ export default class OracleDriver extends AbstractDriver {
                             resp.DATA_LENGTH > 0 ? resp.DATA_LENGTH : undefined;
                     }
 
-                    if (columnType) {
-                        ent.columns.push({
-                            generated,
-                            type: columnType,
-                            default: defaultValue,
-                            options,
-                            tscName,
-                            tscType
-                        });
-                    }
+                    ent.columns.push({
+                        generated,
+                        type: columnType,
+                        default: defaultValue,
+                        options,
+                        tscName,
+                        tscType
+                    });
                 });
         });
         return entities;

--- a/src/drivers/PostgresDriver.ts
+++ b/src/drivers/PostgresDriver.ts
@@ -105,15 +105,16 @@ export default class PostgresDriver extends AbstractDriver {
                             resp.data_type === "ARRAY"
                         ) {
                             TomgUtils.LogError(
-                                `Unknown ${resp.data_type} column type: ${resp.udt_name}  table name: ${resp.table_name} column name: ${resp.column_name}`
+                                `Unknown ${resp.data_type} column type: ${resp.udt_name} table name: ${resp.table_name} column name: ${resp.column_name}`
                             );
                         } else {
                             TomgUtils.LogError(
-                                `Unknown column type: ${resp.data_type}  table name: ${resp.table_name} column name: ${resp.column_name}`
+                                `Unknown column type: ${resp.data_type} table name: ${resp.table_name} column name: ${resp.column_name}`
                             );
                         }
                         return;
                     }
+
                     const columnType = columnTypes.sqlType;
                     let tscType = columnTypes.tsType;
                     if (columnTypes.isArray) options.array = true;
@@ -177,7 +178,7 @@ export default class PostgresDriver extends AbstractDriver {
             isArray: boolean;
             enumValues: string[];
         } = {
-            tsType: "NonNullable<unknown>",
+            tsType: "",
             sqlType: dataType,
             isArray: false,
             enumValues: []
@@ -390,6 +391,9 @@ export default class PostgresDriver extends AbstractDriver {
                         }
                         break;
                 }
+                break;
+            default:
+                ret.tsType = "NonNullable<unknown>";
                 break;
         }
         return ret;

--- a/src/drivers/SqliteDriver.ts
+++ b/src/drivers/SqliteDriver.ts
@@ -65,7 +65,7 @@ export default class SqliteDriver extends AbstractDriver {
                 }>(`PRAGMA table_info('${ent.tscName}');`);
                 response.forEach(resp => {
                     const tscName = resp.name;
-                    let tscType = "";
+                    let tscType = "NonNullable<unknown>";
                     const options: Column["options"] = { name: resp.name };
                     if (resp.notnull === 0) options.nullable = true;
                     const isPrimary = resp.pk > 0 ? true : undefined;

--- a/src/drivers/SqliteDriver.ts
+++ b/src/drivers/SqliteDriver.ts
@@ -65,7 +65,7 @@ export default class SqliteDriver extends AbstractDriver {
                 }>(`PRAGMA table_info('${ent.tscName}');`);
                 response.forEach(resp => {
                     const tscName = resp.name;
-                    let tscType = "NonNullable<unknown>";
+                    let tscType = "";
                     const options: Column["options"] = { name: resp.name };
                     if (resp.notnull === 0) options.nullable = true;
                     const isPrimary = resp.pk > 0 ? true : undefined;
@@ -164,6 +164,7 @@ export default class SqliteDriver extends AbstractDriver {
                             tscType = "Date";
                             break;
                         default:
+                            tscType = "NonNullable<unknown>";
                             TomgUtils.LogError(
                                 `Unknown column type: ${columnType}  table name: ${ent.tscName} column name: ${resp.name}`
                             );
@@ -218,17 +219,15 @@ export default class SqliteDriver extends AbstractDriver {
                         );
                     }
 
-                    if (columnType) {
-                        ent.columns.push({
-                            generated,
-                            primary: isPrimary,
-                            type: columnType,
-                            default: defaultValue,
-                            options,
-                            tscName,
-                            tscType
-                        });
-                    }
+                    ent.columns.push({
+                        generated,
+                        primary: isPrimary,
+                        type: columnType,
+                        default: defaultValue,
+                        options,
+                        tscName,
+                        tscType
+                    });
                 });
             })
         );

--- a/src/templates/entity.mst
+++ b/src/templates/entity.mst
@@ -6,7 +6,7 @@ import { {{toEntityName .}} } from './{{toFileName .}}'
 {{/inline}}
 {{#*inline "Column"}}
 {{#generated}}@PrimaryGeneratedColumn({ type:"{{type}}", {{/generated}}{{^generated}}@Column("{{type}}",{ {{#primary}}primary:{{primary}},{{/primary}}{{/generated}}{{json options}}{{#default}},default: {{.}},{{/default}} })
-{{printPropertyVisibility}}{{toPropertyName tscName}}{{strictMode}}:{{tscType}};
+{{printPropertyVisibility}}{{toPropertyName tscName}}{{strictMode}}:{{tscType}}{{#if options.nullable}} | null{{/if}};
 
 {{/inline}}
 {{#*inline "JoinColumnOptions"}}

--- a/test/drivers/MssqlDriver.test.ts
+++ b/test/drivers/MssqlDriver.test.ts
@@ -74,7 +74,7 @@ describe("MssqlDriver", () => {
                     COLUMN_DEFAULT: "'a'",
                     COLUMN_NAME: "name",
                     DATA_TYPE: "int",
-                    IS_NULLABLE: "YES",
+                    IS_NULLABLE: "NO",
                     NUMERIC_PRECISION: 0,
                     NUMERIC_SCALE: 0,
                     IsIdentity: 1
@@ -99,7 +99,6 @@ describe("MssqlDriver", () => {
         const expected: Entity[] = JSON.parse(JSON.stringify(entities));
         expected[0].columns.push({
             options: {
-                nullable: true,
                 name: "name"
             },
             type: "int",

--- a/test/integration/github-issues/227/entity/Post.ts
+++ b/test/integration/github-issues/227/entity/Post.ts
@@ -1,0 +1,15 @@
+import { PrimaryGeneratedColumn, Column, Entity, OneToOne, JoinColumn, Index } from "typeorm";
+
+@Entity("Post")
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column("varchar", { nullable: true })
+    title: string | null;
+
+    @Column()
+    text: string;
+
+}


### PR DESCRIPTION
Nullable columns now also add "| null" to the type declaration.

Unknown DB types now generate properties with type "NonNullable\<unknown>\" that also includes "| null" if the column is nullable.


The "| null" existed before, except it was also there for relations. This PR doesn't restore it for relations... I'm not sure what's the effect is on TypeORM when one of the columns in a relation is nullable and is set to null. All I know for sure is that NULL is a valid value on nullable columns, and as such should be included in the types of the column.