### PR TITLE
Provide main entrypoint and generated typings to use the core as a library

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.3.5",
   "description": "Generates models for TypeORM from existing databases.",
   "bin": "bin/typeorm-model-generator",
+  "main": "./dist/src/library.js",
+  "types": "./dist/src/library.d.ts",
   "scripts": {
     "start": "ts-node ./src/index.ts",
-    "build": "npm run clean && tsc && ncp src/entity.mst dist/src/entity.mst",
+    "build": "npm run clean && tsc --declaration && ncp src/entity.mst dist/src/entity.mst",
     "prepare": "npm run build",
     "pretest": "tsc --noEmit",
     "test": "nyc --reporter=lcov ts-node ./node_modules/mocha/bin/_mocha test/**/*.test.ts  -- -R spec --bail",

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,21 +1,22 @@
+import RelationInfo from "./models/RelationInfo";
+import ColumnInfo from "./models/ColumnInfo";
+import IndexColumnInfo from "./models/IndexColumnInfo";
+import IndexInfo from "./models/IndexInfo";
+import EntityInfo from "./models/EntityInfo";
+import RelationTempInfo from "./models/RelationTempInfo";
+
+// models exports - there may be a more succinct way to export default classes,
+// but this was the only one I could find that seemed happy
+export type RelationInfo = RelationInfo;
+export type ColumnInfo = ColumnInfo;
+export type IndexColumnInfo = IndexColumnInfo;
+export type IndexInfo = IndexInfo;
+export type EntityInfo = EntityInfo;
+export type RelationTempInfo = RelationTempInfo;
+
 export * from "./AbstractNamingStrategy";
 export * from "./Engine";
 export * from "./IGenerationOptions";
 export * from "./IConnectionOptions";
 export * from "./NamingStrategy";
 export * from "./Utils";
-
-// models exports - there may be a more succinct way to export default classes,
-// but this was the only one I could find that seemed happy
-import RelationInfo from "./models/RelationInfo";
-export type RelationInfo = RelationInfo;
-import ColumnInfo from "./models/ColumnInfo";
-export type ColumnInfo = ColumnInfo;
-import IndexColumnInfo from "./models/IndexColumnInfo";
-export type IndexColumnInfo = IndexColumnInfo;
-import IndexInfo from "./models/IndexInfo";
-export type IndexInfo = IndexInfo;
-import EntityInfo from "./models/EntityInfo";
-export type EntityInfo = EntityInfo;
-import RelationTempInfo from "./models/RelationTempInfo";
-export type RelationTempInfo = RelationTempInfo;

--- a/src/library.ts
+++ b/src/library.ts
@@ -4,3 +4,18 @@ export * from "./IGenerationOptions";
 export * from "./IConnectionOptions";
 export * from "./NamingStrategy";
 export * from "./Utils";
+
+// models exports - there may be a more succinct way to export default classes,
+// but this was the only one I could find that seemed happy
+import RelationInfo from "./models/RelationInfo";
+export type RelationInfo = RelationInfo;
+import ColumnInfo from "./models/ColumnInfo";
+export type ColumnInfo = ColumnInfo;
+import IndexColumnInfo from "./models/IndexColumnInfo";
+export type IndexColumnInfo = IndexColumnInfo;
+import IndexInfo from "./models/IndexInfo";
+export type IndexInfo = IndexInfo;
+import EntityInfo from "./models/EntityInfo";
+export type EntityInfo = EntityInfo;
+import RelationTempInfo from "./models/RelationTempInfo";
+export type RelationTempInfo = RelationTempInfo;

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,0 +1,6 @@
+export * from "./AbstractNamingStrategy";
+export * from "./Engine";
+export * from "./IGenerationOptions";
+export * from "./IConnectionOptions";
+export * from "./NamingStrategy";
+export * from "./Utils";


### PR DESCRIPTION
This library is incredibly useful as is, but I had a need to include the core database introspection and parsing into relations in a project. So, I created a basic library.ts file which exports the necessary classes, added the flag for to tsc generate the typings, and included these references in the package.json.

This enables the use of the library like so:

```
import { createDriver, dataCollectionPhase } from 'typeorm-model-generator';
...

let dbModel = await dataCollectionPhase(driver, {
      host: 'localhost',
      port: 3306,
      schemaName: 'schema',
      databaseName: 'database',
      databaseType: 'mysql',
      user: 'user',
      password: 'password',
      ssl: true,
      timeout: 30000
    });

```