### PR TITLE
Fix type NamingStrategy

### DIFF
--- a/src/ModelCustomization.ts
+++ b/src/ModelCustomization.ts
@@ -5,20 +5,12 @@ import IGenerationOptions from "./IGenerationOptions";
 import * as NamingStrategy from "./NamingStrategy";
 import * as TomgUtils from "./Utils";
 
-type NamingStrategy = {
-    enablePluralization: typeof NamingStrategy.enablePluralization;
-    relationIdName: typeof NamingStrategy.relationIdName;
-    relationName: typeof NamingStrategy.relationName;
-    columnName: typeof NamingStrategy.columnName;
-    entityName: typeof NamingStrategy.entityName;
-};
-
 export default function modelCustomizationPhase(
     dbModel: Entity[],
     generationOptions: IGenerationOptions,
     defaultValues: DataTypeDefaults
 ): Entity[] {
-    const namingStrategy: NamingStrategy = {
+    const namingStrategy: typeof NamingStrategy = {
         enablePluralization: NamingStrategy.enablePluralization,
         columnName: NamingStrategy.columnName,
         entityName: NamingStrategy.entityName,
@@ -32,7 +24,7 @@ export default function modelCustomizationPhase(
         // TODO: change form of logging
         const req = TomgUtils.requireLocalFile(
             generationOptions.customNamingStrategyPath
-        ) as Partial<NamingStrategy>;
+        ) as Partial<typeof NamingStrategy>;
         if (req.columnName) {
             console.log(
                 `[${new Date().toLocaleTimeString()}] Using custom naming strategy for column names.`
@@ -235,7 +227,7 @@ function addImportsAndGenerationOptions(
 }
 
 function applyNamingStrategy(
-    namingStrategy: NamingStrategy,
+    namingStrategy: typeof NamingStrategy,
     dbModel: Entity[]
 ): Entity[] {
     let retVal = changeRelationNames(dbModel);

--- a/src/ModelCustomization.ts
+++ b/src/ModelCustomization.ts
@@ -4,20 +4,13 @@ import { Entity } from "./models/Entity";
 import IGenerationOptions from "./IGenerationOptions";
 import * as NamingStrategy from "./NamingStrategy";
 import * as TomgUtils from "./Utils";
-import { Relation } from "./models/Relation";
-import { RelationId } from "./models/RelationId";
-import { Column } from "./models/Column";
 
 type NamingStrategy = {
-    enablePluralization: (value: boolean) => void;
-    relationIdName: (
-        relationId: RelationId,
-        relation: Relation,
-        owner: Entity
-    ) => string;
-    relationName: (relation: Relation, owner: Entity) => string;
-    columnName: (columnName: string, column?: Column) => string;
-    entityName: (entityName: string, entity?: Entity) => string;
+    enablePluralization: typeof NamingStrategy.enablePluralization;
+    relationIdName: typeof NamingStrategy.relationIdName;
+    relationName: typeof NamingStrategy.relationName;
+    columnName: typeof NamingStrategy.columnName;
+    entityName: typeof NamingStrategy.entityName;
 };
 
 export default function modelCustomizationPhase(

--- a/src/NamingStrategy.ts
+++ b/src/NamingStrategy.ts
@@ -1,7 +1,10 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { plural } from "pluralize";
 import * as changeCase from "change-case";
 import { Relation } from "./models/Relation";
 import { RelationId } from "./models/RelationId";
+import { Entity } from "./models/Entity";
+import { Column } from "./models/Column";
 
 let pluralize: boolean;
 
@@ -11,7 +14,8 @@ export function enablePluralization(value: boolean) {
 
 export function relationIdName(
     relationId: RelationId,
-    relation: Relation
+    relation: Relation,
+    owner?: Entity
 ): string {
     const columnOldName = relationId.fieldName;
 
@@ -35,7 +39,7 @@ export function relationIdName(
     return newColumnName;
 }
 
-export function relationName(relation: Relation): string {
+export function relationName(relation: Relation, owner?: Entity): string {
     const columnOldName = relation.fieldName;
 
     const isRelationToMany =
@@ -66,10 +70,10 @@ export function relationName(relation: Relation): string {
     return newColumnName;
 }
 
-export function entityName(oldEntityName: string): string {
+export function entityName(oldEntityName: string, entity?: Entity): string {
     return oldEntityName;
 }
 
-export function columnName(oldColumnName: string): string {
+export function columnName(oldColumnName: string, column?: Column): string {
     return oldColumnName;
 }


### PR DESCRIPTION
When using custom naming strategy, the value and type passed in do not match.
![image](https://user-images.githubusercontent.com/1300172/74901084-1a2d1600-53e5-11ea-9d2a-879199ff0503.png)

Entity and Column are being passed in.
https://github.com/Kononnable/typeorm-model-generator/blob/master/src/ModelCustomization.ts
```ts
let newName = namingStrategy.relationIdName(relationId, relation, entity);
let newName = namingStrategy.relationName(relation, entity);
let newName = namingStrategy.columnName(column.tscName, column);
const newName = namingStrategy.entityName(entity.tscName, entity);
```
