### PR TITLE
ignore table have numberic column name

### DIFF
--- a/src/ModelGeneration.ts
+++ b/src/ModelGeneration.ts
@@ -80,13 +80,18 @@ function generateModels(
                   )
                 : rendered
         );
-        const formatted = Prettier.format(withImportStatements, {
-            parser: "typescript"
-        });
-        fs.writeFileSync(resultFilePath, formatted, {
-            encoding: "UTF-8",
-            flag: "w"
-        });
+        try {
+            const formatted = Prettier.format(withImportStatements, {
+                parser: 'typescript',
+            });
+            fs.writeFileSync(resultFilePath, formatted, {
+                encoding: 'UTF-8',
+                flag: 'w',
+            });
+        } catch (error) {
+            console.log('Trouble when generate for table: ', element.sqlName);
+            console.log(error);
+        }
     });
 }
 

--- a/src/ModelGeneration.ts
+++ b/src/ModelGeneration.ts
@@ -80,18 +80,22 @@ function generateModels(
                   )
                 : rendered
         );
+        let formatted = "";
         try {
-            const formatted = Prettier.format(withImportStatements, {
-                parser: 'typescript',
-            });
-            fs.writeFileSync(resultFilePath, formatted, {
-                encoding: 'UTF-8',
-                flag: 'w',
+            formatted = Prettier.format(withImportStatements, {
+                parser: "typescript"
             });
         } catch (error) {
-            console.log('Trouble when generate for table: ', element.sqlName);
+            console.log(
+                "There were some problems with model generation for table: ",
+                element.sqlName
+            );
             console.log(error);
         }
+        fs.writeFileSync(resultFilePath, formatted, {
+            encoding: "UTF-8",
+            flag: "w"
+        });
     });
 }
 

--- a/src/ModelGeneration.ts
+++ b/src/ModelGeneration.ts
@@ -86,11 +86,12 @@ function generateModels(
                 parser: "typescript"
             });
         } catch (error) {
-            console.log(
+            console.error(
                 "There were some problems with model generation for table: ",
                 element.sqlName
             );
-            console.log(error);
+            console.error(error);
+            formatted = withImportStatements;
         }
         fs.writeFileSync(resultFilePath, formatted, {
             encoding: "UTF-8",


### PR DESCRIPTION
I'm currenly working with a mysql database which have some tables that contain columns with numeric in name (Ex: 2TierCostumer,...). When generating, it stop immediately when meet an **error table** (has numeric column name). What i need is a model of orther table (don't has numeric column name)  but can't get it because the **error table** has stopped the process. 

Since we haven't had option to choose specific table yet, so i think it should
=> continue generating, just log the **error table** with it's error

