### PR TITLE
Fixed columns order in generated indexes decorators

### DIFF
--- a/src/drivers/PostgresDriver.ts
+++ b/src/drivers/PostgresDriver.ts
@@ -470,7 +470,8 @@ export default class PostgresDriver extends AbstractDriver {
             columnname: string;
             ordernum: number;
         }[] = (
-            await this.Connection.query(`SELECT c.relname AS indexname,
+            await this.Connection.query(`SELECT
+                 c.relname AS indexname,
                  a.attname AS columnname,
                  a.attnum AS ordernum
                  FROM pg_attribute a
@@ -478,7 +479,7 @@ export default class PostgresDriver extends AbstractDriver {
                  LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
                  WHERE c.relkind = 'i'::char
                  AND a.attnum > 0
-                 AND n.nspname in ('public')
+                 AND n.nspname in (${schema})
                  ORDER BY c.relname, a.attnum;
             `)
         ).rows;


### PR DESCRIPTION
Problem:
We has two composite indexes in table:
- constraint users_usersorg_u1 unique (user_id, org_id),
- constraint users_usersorg_u2 unique (org_id, user_id)

When typeorm-model-generator running, it load indexes without information about column ordering.
Result of generation:
```typescript
@Index('users_usersorg_u1', ['orgId', 'userId'], { unique: true })
@Index('users_usersorg_u2', ['orgId', 'userId'], { unique: true })
```

Decision:
Loading information about index order and pregeneration hash map for array indexes
Result of generation:
```typescript
@Index('users_usersorg_u1', ['userId', 'orgId'], { unique: true })
@Index('users_usersorg_u2', ['orgId', 'userId'], { unique: true })
```