### PR TITLE
Fixed generated column defaul value

### DIFF
--- a/src/drivers/PostgresDriver.ts
+++ b/src/drivers/PostgresDriver.ts
@@ -676,7 +676,7 @@ export default class PostgresDriver extends AbstractDriver {
         if (["json", "jsonb"].some((x) => x === dataType)) {
             return `${defaultValue.slice(1, defaultValue.length - 1)}`;
         }
-        return /^'(.*)?'|[-].?[\d]+$/.test(defaultValue)
+        return /^'(.*)?'|[-]?[\d.]+$/.test(defaultValue)
             ? defaultValue
             : `() => "${defaultValue}"`;
     }

--- a/src/drivers/PostgresDriver.ts
+++ b/src/drivers/PostgresDriver.ts
@@ -671,11 +671,13 @@ export default class PostgresDriver extends AbstractDriver {
         if (!defaultValue) {
             return undefined;
         }
-        defaultValue = defaultValue.replace(/'::[\w ]*/, "'");
+        defaultValue = defaultValue.replace(/'::[\w" ]*/, "'");
 
         if (["json", "jsonb"].some((x) => x === dataType)) {
             return `${defaultValue.slice(1, defaultValue.length - 1)}`;
         }
-        return `() => "${defaultValue}"`;
+        return /^'(.*)?'|[-].?[\d]+$/.test(defaultValue)
+            ? defaultValue
+            : `() => "${defaultValue}"`;
     }
 }


### PR DESCRIPTION
Problem:
We has some column in table:
```
repeat        "journalArchive_repeat_enum" default 'first'::"journalArchive_repeat_enum" not null,
```
and some related type:
```
create type "journalArchive_repeat_enum" as enum ('first', 'repeat');
```

While generating model class process returns error.
```
There were some problems with model generation for table:  journalArchive
SyntaxError: ',' expected. (29:80)
  27 | status:"done" | "error" | "cancel";
  28 |
> 29 | @Column("enum",{ name:"repeat",enum:["first","repeat"],default: () => "'first'"journalArchive_repeat_enum"", })
     |                                                                                ^
  30 | repeat:"first" | "repeat";
```
also typeorm fails attempts of loading default fields in column with single quotes, after tslint
```
default: () => '\'start\'',
```

Decision:
Checking string and numbers defaults and generating it as simple value of default field:
Result of generation:
```typescript
default: 'start'

@Column('enum', {
	name: 'repeat',
	enum: ['first', 'repeat'],
	default: 'first'
})
```