### PR TITLE
Checks if schema is defined and use it in typeorm PK name generation

### DIFF
--- a/src/ModelCustomization.ts
+++ b/src/ModelCustomization.ts
@@ -98,13 +98,18 @@ function removeIndicesGeneratedByTypeorm(dbModel: Entity[]): Entity[] {
         const primaryColumns = entity.columns
             .filter((v) => v.primary)
             .map((v) => v.tscName);
+
+        const ormTableName = entity?.schema
+            ? `${entity.schema}.${entity.tscName}`
+            : entity.tscName;
+
         entity.indices = entity.indices.filter(
             (v) =>
                 !(
                     v.primary &&
                     v.name ===
                         namingStrategy.primaryKeyName(
-                            entity.tscName,
+                            ormTableName,
                             primaryColumns
                         )
                 )
@@ -114,11 +119,11 @@ function removeIndicesGeneratedByTypeorm(dbModel: Entity[]): Entity[] {
             .forEach((rel) => {
                 const columnNames = rel.joinColumnOptions!.map((v) => v.name);
                 const idxName = namingStrategy.relationConstraintName(
-                    entity.tscName,
+                    ormTableName,
                     columnNames
                 );
                 const fkName = namingStrategy.foreignKeyName(
-                    entity.tscName,
+                    ormTableName,
                     columnNames
                 );
                 entity.indices = entity.indices.filter(
@@ -126,6 +131,7 @@ function removeIndicesGeneratedByTypeorm(dbModel: Entity[]): Entity[] {
                 );
             });
     });
+
     return dbModel;
 }
 function removeColumnsInRelation(dbModel: Entity[]): Entity[] {


### PR DESCRIPTION
If some project not use schema config option, the primary keys generates in depending by table name. But if schema is given, PK use `schema.table_name` structure in generation of indexes. F.e. in another project db was synchronized with models and in ormconfig was not having schema options. Now we run generator and give schema option. Our generation process use only table name and hash of current index not matched with firstly generated name of index. So now we get `@Index` decorator for primary key:
```
@Index('PK_7656c0633e6c348fef83084817', ['id'], { unique: true })
```