### PR TITLE
Add a 'smart' choice to the --strictMode option

### DIFF
--- a/src/IGenerationOptions.ts
+++ b/src/IGenerationOptions.ts
@@ -19,7 +19,7 @@ export default interface IGenerationOptions {
     generateConstructor: boolean;
     customNamingStrategyPath: string;
     relationIds: boolean;
-    strictMode: "none" | "?" | "!";
+    strictMode: "none" | "?" | "!" | "smart";
     skipSchema: boolean;
     indexFile: boolean;
     exportType: "named" | "default";

--- a/src/ModelGeneration.ts
+++ b/src/ModelGeneration.ts
@@ -238,10 +238,19 @@ function createHandlebarsHelpers(generationOptions: IGenerationOptions): void {
             ? entityName
             : `{${entityName}}`
     );
-    Handlebars.registerHelper("strictMode", () =>
-        generationOptions.strictMode !== "none"
-            ? generationOptions.strictMode
-            : ""
+    Handlebars.registerHelper(
+        "strictMode",
+        (defaultValue?: string | object) => {
+            if (generationOptions.strictMode === "smart") {
+                return defaultValue && typeof defaultValue === "string"
+                    ? "?"
+                    : "!";
+            }
+
+            return generationOptions.strictMode !== "none"
+                ? generationOptions.strictMode
+                : "";
+        }
     );
     Handlebars.registerHelper({
         and: (v1, v2) => v1 && v2,

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,7 +271,7 @@ function checkYargsParameters(options: options): options {
                 "Skip schema generation for specific tables. You can pass multiple values separated by comma",
         },
         strictMode: {
-            choices: ["none", "?", "!"],
+            choices: ["none", "?", "!", "smart"],
             default: options.generationOptions.strictMode,
             describe: "Mark fields as optional(?) or non-null(!)",
         },

--- a/src/templates/entity.mst
+++ b/src/templates/entity.mst
@@ -6,7 +6,7 @@ import {{localImport (toEntityName .)}} from './{{toFileName .}}'
 {{/inline}}
 {{#*inline "Column"}}
 {{#generated}}@PrimaryGeneratedColumn({ type:"{{type}}", {{/generated}}{{^generated}}@Column("{{type}}",{ {{#primary}}primary:{{primary}},{{/primary}}{{/generated}}{{json options}}{{#default}},default: {{.}},{{/default}} })
-{{printPropertyVisibility}}{{toPropertyName tscName}}{{strictMode}}:{{tscType}}{{#if options.nullable}} | null{{/if}};
+{{printPropertyVisibility}}{{toPropertyName tscName}}{{strictMode default}}:{{tscType}}{{#if options.nullable}} | null{{/if}};
 
 {{/inline}}
 {{#*inline "JoinColumnOptions"}}

--- a/test/modelCustomization/modelCustomization.test.ts
+++ b/test/modelCustomization/modelCustomization.test.ts
@@ -30,6 +30,19 @@ describe("Model customization phase", async () => {
                     options: { name: "name" },
                     tscName: "name",
                     tscType: "string"
+                },
+                {
+                    type: "character varying",
+                    options: { name: "bio", nullable: true },
+                    tscName: "bio",
+                    tscType: "string"
+                },
+                {
+                    type: "character varying",
+                    options: { name: "city", nullable: true },
+                    default: "() => \"'Pontonx sur l'adour'\"",
+                    tscName: "city",
+                    tscType: "string"
                 }
             ],
             indices: [
@@ -75,6 +88,13 @@ describe("Model customization phase", async () => {
                     type: "character varying",
                     options: { name: "text" },
                     tscName: "text",
+                    tscType: "string"
+                },
+                {
+                    type: "character varying",
+                    options: { name: "tags" },
+                    default: "() => \"'to-be-tagged'\"",
+                    tscName: "tags",
                     tscType: "string"
                 }
             ],
@@ -610,6 +630,42 @@ describe("Model customization phase", async () => {
             expect(postAuthorContent).to.have.string(`id?: number;`);
             expect(postAuthorContent).to.have.string(`name?: string;`);
             expect(postAuthorContent).to.have.string(`posts?: Post[];`);
+
+            compileGeneratedModel(generationOptions.resultsPath, [""]);
+        });
+        it("smart", async () => {
+            const data = generateSampleData();
+            const generationOptions = generateGenerationOptions();
+            clearGenerationDir();
+
+            generationOptions.strictMode = "smart";
+            const customizedModel = modelCustomizationPhase(
+                data,
+                generationOptions,
+                {}
+            );
+            modelGenerationPhase(
+                getDefaultConnectionOptions(),
+                generationOptions,
+                customizedModel
+            );
+            const filesGenPath = path.resolve(resultsPath, "entities");
+            const postContent = fs
+                .readFileSync(path.resolve(filesGenPath, "Post.ts"))
+                .toString();
+            const postAuthorContent = fs
+                .readFileSync(path.resolve(filesGenPath, "PostAuthor.ts"))
+                .toString();
+            expect(postContent).to.have.string(`id!: number;`);
+            expect(postContent).to.have.string(`title!: string;`);
+            expect(postContent).to.have.string(`text!: string;`);
+            expect(postContent).to.have.string(`tags?: string;`);
+            expect(postContent).to.have.string(`author!: PostAuthor;`);
+            expect(postAuthorContent).to.have.string(`id!: number;`);
+            expect(postAuthorContent).to.have.string(`name!: string;`);
+            expect(postAuthorContent).to.have.string(`bio!: string | null;`);
+            expect(postAuthorContent).to.have.string(`city?: string | null;`);
+            expect(postAuthorContent).to.have.string(`posts!: Post[];`);
 
             compileGeneratedModel(generationOptions.resultsPath, [""]);
         });


### PR DESCRIPTION
I am a new user of this awesome tool (and of typeorm as well).
I use `strictMode` and I had a hard time choosing what I should use between `? (optionnal)` and `! (non-null)`.

I am real new to typeorm so I could be totally wrong in my understanding of all this, but there are my thoughts:

- When a column has a default value set, then it makes sense to being able to avoid this when creating the associated entity before a save for example
> The `--strictMode smart` option makes class member optional or non-null based on the presence of a default value on the associated db column
- But then, still, you would have a typing issue with the primary auto-generated keys that should be optional as well to allow creating a new entity, leaving to the database the work of generating it. What do you think ? Should be pretty straightforward to add.
- `smart` might not be the good word here, I let you tell me how you would name it

---

Anyways, I hope to have your insights on this one as I could have misjudge the way people use `typeorm` with strict mode.