### PR TITLE
Support export-abstract-class

### DIFF
--- a/src/IGenerationOptions.ts
+++ b/src/IGenerationOptions.ts
@@ -23,6 +23,7 @@ export default interface IGenerationOptions {
     skipSchema: boolean;
     indexFile: boolean;
     exportType: "named" | "default";
+    exportAbstractClass: boolean;
 }
 
 export const eolConverter = {
@@ -49,6 +50,7 @@ export function getDefaultGenerationOptions(): IGenerationOptions {
         skipSchema: false,
         indexFile: false,
         exportType: "named",
+        exportAbstractClass: false,
     };
     return generationOptions;
 }

--- a/src/ModelCustomization.ts
+++ b/src/ModelCustomization.ts
@@ -222,6 +222,9 @@ function addImportsAndGenerationOptions(
         if (generationOptions.generateConstructor) {
             entity.generateConstructor = true;
         }
+        if (generationOptions.exportAbstractClass) {
+            entity.exportAbstractClass = true;
+        }
     });
     return dbModel;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,6 +285,11 @@ function checkYargsParameters(options: options): options {
             default: options.generationOptions.exportType === "default",
             describe: "Generate index file",
         },
+        exportAbstractClass: {
+            boolean: true,
+            default: options.generationOptions.exportAbstractClass,
+            describe: "Export generated models as abstract classes",
+        },
     });
 
     options.connectionOptions.databaseName = argv.d;
@@ -325,7 +330,7 @@ function checkYargsParameters(options: options): options {
     options.generationOptions.exportType = argv.defaultExport
         ? "default"
         : "named";
-
+    options.generationOptions.exportAbstractClass = argv.exportAbstractClass;
     return options;
 }
 
@@ -558,6 +563,12 @@ async function useInquirer(options: options): Promise<options> {
                                 options.generationOptions.exportType ===
                                 "default",
                         },
+                        {
+                            name: "Export generated models as abstract classes",
+                            value: "exportAbstractClass",
+                            checked:
+                                options.generationOptions.exportAbstractClass,
+                        },
                     ],
                     message: "Available customizations",
                     name: "selected",
@@ -616,6 +627,9 @@ async function useInquirer(options: options): Promise<options> {
         )
             ? "default"
             : "named";
+        options.generationOptions.exportAbstractClass = customizations.includes(
+            "exportAbstractClass"
+        );
 
         if (customizations.includes("namingStrategy")) {
             const namingStrategyPath = (

--- a/src/models/Entity.ts
+++ b/src/models/Entity.ts
@@ -18,4 +18,5 @@ export type Entity = {
     fileImports: string[];
     activeRecord?: true;
     generateConstructor?: true;
+    exportAbstractClass?: true;
 };

--- a/src/templates/entity.mst
+++ b/src/templates/entity.mst
@@ -32,8 +32,8 @@ import {{localImport (toEntityName .)}} from './{{toFileName .}}'
 {{/inline}}
 {{#*inline "Entity"}}
 {{#indices}}{{> Index}}{{/indices~}}
-@Entity("{{sqlName}}"{{#schema}} ,{schema:"{{.}}"{{#if ../database}}, database:"{{../database}}"{{/if}} } {{/schema}})
-export {{defaultExport}} class {{toEntityName tscName}}{{#activeRecord}} extends BaseEntity{{/activeRecord}} {
+{{#unless exportAbstractClass}}@Entity("{{sqlName}}"{{#schema}} ,{schema:"{{.}}"{{#if ../database}}, database:"{{../database}}"{{/if}} } {{/schema}}){{/unless}}
+export {{defaultExport}}{{#exportAbstractClass}}abstract{{/exportAbstractClass}} class {{toEntityName tscName}}{{#activeRecord}} extends BaseEntity{{/activeRecord}} {
 
 {{#columns}}{{> Column}}{{/columns~}}
 {{#relations}}{{> Relation}}{{/relations~}}

--- a/test/modelCustomization/modelCustomization.test.ts
+++ b/test/modelCustomization/modelCustomization.test.ts
@@ -451,6 +451,44 @@ describe("Model customization phase", async () => {
 
         compileGeneratedModel(generationOptions.resultsPath, [""]);
     });
+    it("exportAbstractClass", async () => {
+        const data = generateSampleData();
+        const generationOptions = generateGenerationOptions();
+        clearGenerationDir();
+
+        generationOptions.exportAbstractClass = true;
+        const customizedModel = modelCustomizationPhase(
+            data,
+            generationOptions,
+            {}
+        );
+        modelGenerationPhase(
+            getDefaultConnectionOptions(),
+            generationOptions,
+            customizedModel
+        );
+        const filesGenPath = path.resolve(resultsPath, "entities");
+        const postContent = fs
+            .readFileSync(path.resolve(filesGenPath, "Post.ts"))
+            .toString();
+        const postAuthorContent = fs
+            .readFileSync(path.resolve(filesGenPath, "PostAuthor.ts"))
+            .toString();
+        expect(postContent).to.have.string(
+            `export abstract class Post `
+        );
+        expect(postAuthorContent).to.have.string(
+            `export abstract class PostAuthor `
+        );
+        expect(postContent).to.not.have.string(
+            `@Entity`
+        );
+        expect(postAuthorContent).to.not.have.string(
+            `@Entity`
+        );
+
+        compileGeneratedModel(generationOptions.resultsPath, [""]);
+    });
     it("skipSchema", async () => {
         const data = generateSampleData();
         const generationOptions = generateGenerationOptions();


### PR DESCRIPTION
When `exportAbstractClass: true`, the generated models will be an abstract class wthout `@Entity`.