### PR TITLE
Makes Postgres driver aware of new identity columns

### DIFF
--- a/src/drivers/PostgresDriver.ts
+++ b/src/drivers/PostgresDriver.ts
@@ -73,7 +73,8 @@ export default class PostgresDriver extends AbstractDriver {
             character_maximum_length: number;
             numeric_precision: number;
             numeric_scale: number;
-            isidentity: string;
+            isidentity: string; // SERIAL identity type
+            is_identity: string; // reccommended INDENTITY type for pg > 10
             isunique: string;
             enumvalues: string | null;
             /* eslint-enable camelcase */
@@ -82,6 +83,7 @@ export default class PostgresDriver extends AbstractDriver {
                 .query(`SELECT table_name,column_name,udt_name,column_default,is_nullable,
                     data_type,character_maximum_length,numeric_precision,numeric_scale,
                     case when column_default LIKE 'nextval%' then 'YES' else 'NO' end isidentity,
+                    is_identity,
         			(SELECT count(*)
             FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
                 inner join INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE cu
@@ -114,7 +116,7 @@ export default class PostgresDriver extends AbstractDriver {
                     if (resp.isunique === "1") options.unique = true;
 
                     const generated =
-                        resp.isidentity === "YES" ? true : undefined;
+                        resp.isidentity === "YES" || resp.is_identity === "YES" ? true : undefined;
                     const defaultValue = generated
                         ? undefined
                         : PostgresDriver.ReturnDefaultValueFunction(


### PR DESCRIPTION
Here's a barebones fix for the issues  #2215, #274 and a handful of other duplicates I'm not too keen to curate.

You'll see more and more of this issue as the new "SQL standard"  approach is getting a gentle push from the postgres peeps. 

Because the issue originates in updates to Postgres 10 and on, it likely breaks 9.5 and 9.6, and all the unsupported versions.  I'll leave what you want to support and how to do it up to you.

'll also let you  address anything beyond this small fix that I made for my own db, while the change is trivial, I found looking for what changes to make time-consuming and i hope this helps you with that.