### PR TITLE
Add ltree type support for PostgreSQL

### DIFF
--- a/src/drivers/PostgresDriver.ts
+++ b/src/drivers/PostgresDriver.ts
@@ -428,6 +428,7 @@ export default class PostgresDriver extends AbstractDriver {
                     case "hstore":
                     case "geography":
                     case "geometry":
+                    case "ltree":
                         ret.sqlType = udtName;
                         break;
                     default:

--- a/test/integration/entityTypes/postgres/entity/Post.ts
+++ b/test/integration/entityTypes/postgres/entity/Post.ts
@@ -189,4 +189,7 @@ export class Post {
 
     @Column("geography")
     geography: string;
+
+    @Column("ltree")
+    ltree: string;
 }


### PR DESCRIPTION
### Description

The ltree type is a popular PostgreSQL extended type definition, and the type creation process has been modified to support ltree.

### Modify Summary

- Added ltree support into driver switch 
- Added ltree test case

### ltree document

https://www.postgresql.org/docs/13/ltree.html