### PR TITLE
fix: fix typecasting problem when using old version mysql

### DIFF
--- a/src/drivers/MysqlDriver.ts
+++ b/src/drivers/MysqlDriver.ts
@@ -493,6 +493,17 @@ export default class MysqlDriver extends AbstractDriver {
             };
         }
 
+        config.typeCast = (field, next) => {
+            switch (field.type) {
+                case "VAR_STRING":
+                    return field.string();
+                case "BLOB":
+                    return field.string();
+                default:
+                    return next();
+            }
+        };
+
         const promise = new Promise<boolean>((resolve, reject) => {
             this.Connection = this.MYSQL.createConnection(config);
 


### PR DESCRIPTION
query return buffer without typecasting

so, this library can not find table pk

`Table table_name has no PK.`